### PR TITLE
Create an RSS Feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out/
 .now
 .env
 .env.build
+public/feed.xml

--- a/buildRss.js
+++ b/buildRss.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const { Feed } = require('feed');
+const matter = require('gray-matter');
+const marked = require('marked');
+
+const feed = new Feed({
+  title: "James Bedont's Writing",
+  description: 'Feed of all the articles written on jamesbedont.com',
+  id: 'https://jamesbedont.com/',
+  link: 'https://jamesbedont.com/',
+  language: 'en',
+  image: 'https://jamesbedont.com/headshot.jpeg',
+  favicon: 'https://jamesbedont.com/favicon.png',
+  copyright: `All rights reserved ${new Date().getFullYear()}, James Bedont`,
+  feedLinks: {
+    json: 'https://jamesbedont.com/json',
+    atom: 'https://jamesbedont.com/atom'
+  },
+  author: {
+    name: 'James Bedont',
+    link: 'https://jamesbedont.com'
+  }
+});
+
+feed.addCategory('Software Development');
+
+const posts = fs.readdirSync(path.join(__dirname, 'posts'));
+posts.map(fileName => {
+  const rawPostContent = fs.readFileSync(
+    path.join(__dirname, 'posts', fileName),
+    'utf8'
+  );
+  const { data: frontMatter, content } = matter(rawPostContent);
+  let postContent = marked(content).replace(
+    /<img src="/g,
+    '<img src="https://jamesbedont.com/'
+  );
+
+  const postUrlSlug = frontMatter.title.toLowerCase().replace(/\s/g, '-');
+  const postUrl = `https://jamesbedont.com/${postUrlSlug}`;
+
+  feed.addItem({
+    title: frontMatter.title,
+    id: postUrl,
+    link: postUrl,
+    content: postContent,
+    author: [
+      {
+        name: 'James Bedont',
+        link: 'https://jamesbedont.com'
+      }
+    ],
+    date: new Date(frontMatter.date)
+  });
+});
+
+feed.items.sort((a, b) => b.date - a.date);
+
+fs.writeFileSync(path.join(__dirname, 'public', 'feed.xml'), feed.rss2());

--- a/now.json
+++ b/now.json
@@ -17,6 +17,10 @@
     {
       "source": "/2016/03/23/GoogleMapsApiIntroduction.html",
       "destination": "/introduction-to-google-maps-api-featuring-es6-promises"
+    },
+    {
+      "source": "/feed",
+      "destination": "/feed.xml"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "next",
-    "build": "next build",
+    "build": "node ./buildRss.js && next build",
     "start": "next start",
     "export": "next export",
     "build:static": "npm run build && npm run export",


### PR DESCRIPTION
- new root file that goes through all the markdown posts extracts their content and generates a rss xml file.
- zeit now redirect rule that takes people from `/feed` to the static asset `/feed.xml`

this works because the posts are local markdown files and to publish a post a deploy will need to happen which will generate a new XML file.