### PR TITLE
Use process.cwd() instead of dirname

### DIFF
--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -39,9 +39,8 @@ PostPage.propTypes = {
 };
 
 export async function getStaticPaths() {
-  console.log(fs.readdirSync(path.join(__dirname, 'var')));
   const posts = fs.readdirSync(
-    '/Users/jamesbedont/Documents/personal-website/posts'
+    path.join(process.cwd(), 'posts')
   );
 
   // Get the paths we want to pre-render based on posts
@@ -59,7 +58,7 @@ export async function getStaticProps({ params }) {
   const titleAsFileName = params.slug;
 
   const post = fs.readFileSync(
-    `/Users/jamesbedont/Documents/personal-website/posts/${titleAsFileName}.md`,
+    path.join(process.cwd(), 'posts', `${titleAsFileName}.md`),
     { encoding: 'utf8' }
   );
   const { content, data: frontMatter } = matter(post);

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,12 +26,10 @@ HomePage.propTypes = {
 
 export async function getStaticProps() {
   const posts = fs
-    .readdirSync('/Users/jamesbedont/Documents/personal-website/posts/')
+    .readdirSync(path.join(process.cwd(), 'posts'))
     .map(postFileName => {
       const fileContents = fs.readFileSync(
-        path.join(
-          `/Users/jamesbedont/Documents/personal-website/posts/${postFileName}`
-        ),
+        path.join(process.cwd(), 'posts', `${postFileName}`),
         { encoding: 'utf8' }
       );
       const { data: frontMatter } = matter(fileContents);


### PR DESCRIPTION
Fixes the issue you're experiencing. `__dirname` is unreliable in many cases hence why you have to use the directory where the command was executed